### PR TITLE
Fix date inconsistencies between the processes when setting a test date

### DIFF
--- a/src/Console/ParallelCommand.php
+++ b/src/Console/ParallelCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Recca0120\LaravelParallel\ResponseIdentifier;
 use Symfony\Component\Console\Command\Command;
@@ -70,6 +71,7 @@ class ParallelCommand extends Command
         $this->addOption('disableCookieEncryption', null, InputOption::VALUE_REQUIRED);
         $this->addOption('user', null, InputOption::VALUE_OPTIONAL);
         $this->addOption('guard', null, InputOption::VALUE_OPTIONAL);
+        $this->addOption('date', null, InputOption::VALUE_OPTIONAL);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -93,7 +95,8 @@ class ParallelCommand extends Command
             ->handleServerVariables($input)
             ->handleFollowRedirects($input)
             ->handleWithCredentials($input)
-            ->handleAuthenticatable($input);
+            ->handleAuthenticatable($input)
+            ->handleDate($input);
 
         return $this->makeTestResponse($input)->baseResponse;
     }
@@ -178,6 +181,17 @@ class ParallelCommand extends Command
             foreach ($values as $value) {
                 $this->withoutMiddleware(...$value);
             }
+        }
+
+        return $this;
+    }
+
+    private function handleDate(InputInterface $input): self
+    {
+        $date = $input->getOption('date');
+
+        if (! empty($date)) {
+            Carbon::setTestNow($date);
         }
 
         return $this;

--- a/src/ParallelRequest.php
+++ b/src/ParallelRequest.php
@@ -5,6 +5,7 @@ namespace Recca0120\LaravelParallel;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Carbon;
 use Recca0120\LaravelParallel\Concerns\InteractsWithAuthentication;
 use Recca0120\LaravelParallel\Concerns\MakesHttpRequests;
 use Recca0120\LaravelParallel\Console\ParallelCommand;
@@ -96,6 +97,7 @@ class ParallelRequest
             '--disableCookieEncryption' => ! $this->encryptCookies,
             '--user' => $this->user,
             '--guard' => $this->guard,
+            '--date' => Carbon::getTestNow()?->toIso8601String(),
             '--ansi',
         ];
     }

--- a/tests/Fixtures/artisan
+++ b/tests/Fixtures/artisan
@@ -2,6 +2,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Orchestra\Testbench\Concerns\CreatesApplication;
@@ -102,6 +103,10 @@ $laravel = new class()
 
         $router->middleware('auth:api')->post('/api/user', function (Request $request) {
             return response()->json($request->user());
+        });
+
+        $router->middleware('web')->get('/date', function (Request $request) {
+            return Carbon::now()->toIso8601String();
         });
     }
 

--- a/tests/ParallelRequestTest.php
+++ b/tests/ParallelRequestTest.php
@@ -3,6 +3,7 @@
 namespace Recca0120\LaravelParallel\Tests;
 
 use Illuminate\Auth\GenericUser;
+use Illuminate\Support\Carbon;
 use Recca0120\LaravelParallel\Tests\Fixtures\User;
 use Throwable;
 
@@ -165,6 +166,18 @@ class ParallelRequestTest extends TestCase
         }
 
         self::assertLessThan(5, microtime(true) - $startTime);
+    }
+
+    public function test_it_should_set_test_date(): void
+    {
+        $testDate = Carbon::parse('2023-01-01 00:00:00');
+        Carbon::setTestNow($testDate);
+
+        $request = ParallelRequest::create();
+
+        $response = $request->get('/date')->wait();
+
+        $response->assertOk()->assertContent($testDate->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
This fixes the test date not being carried over from the test case to the parallel request process.

Thanks for your work on this, it's been a huge help.