### PR TITLE
Allow the database path to be specified using an environment variable

### DIFF
--- a/src/ParallelServiceProvider.php
+++ b/src/ParallelServiceProvider.php
@@ -13,7 +13,7 @@ class ParallelServiceProvider extends ServiceProvider
         config([
             'database.connections.laravel-parallel' => [
                 'driver' => 'sqlite',
-                'database' => database_path('laravel-parallel.sqlite'),
+                'database' => \env('DB_PARALLEL_DATABASE', database_path('laravel-parallel.sqlite')),
                 'prefix' => '',
                 'foreign_key_constraints' => true,
             ],


### PR DESCRIPTION
This is a small change to allow the database path to be specified using the `DB_PARALLEL_DATABASE` environment variable.

The variable naming follows Laravel's `DB_DATABASE` variable naming for the SQLite database path.